### PR TITLE
fix(config): loadConfig return when passing custom interface

### DIFF
--- a/.changeset/plenty-seahorses-cough.md
+++ b/.changeset/plenty-seahorses-cough.md
@@ -1,0 +1,5 @@
+---
+"@dsmrt/axiom-config": patch
+---
+
+fix load config return with custom interfaces

--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -22,7 +22,7 @@ interface ConfigMethods {
   asParameterPath(name: string): string;
 }
 
-export class ConfigContainer<T = object> implements BaseConfig, ConfigMethods {
+export class ConfigContainer implements BaseConfig, ConfigMethods {
   readonly name: string;
   readonly env: string;
   readonly aws: AwsConfigs;
@@ -97,7 +97,7 @@ export const loadConfig = <T extends object>(
   const configObject = mergeDeep(baseConfig, overrides);
 
   // merge env file
-  return new ConfigContainer(configObject);
+  return new ConfigContainer(configObject) as ConfigContainer & T;
 };
 
 /**

--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -28,7 +28,7 @@ export class ConfigContainer<T = object> implements BaseConfig, ConfigMethods {
   readonly aws: AwsConfigs;
   readonly prodEnvName?: string = "prod";
 
-  constructor(config: T & BaseConfig) {
+  constructor(config: BaseConfig) {
     this.name = config.name;
     this.env = config.env;
     this.aws = config.aws;
@@ -80,7 +80,7 @@ export const importConfigFromPath = (path: string): Config => {
 
 export const loadConfig = <T extends object>(
   input?: LoadConfigInput,
-): ConfigContainer<T> => {
+): ConfigContainer & T => {
   // get the base file
   const baseConfigFile = configPath(input);
 


### PR DESCRIPTION
Making interface return work like it should.

Example:
```typescript
export interface MyAxiomConfig {
  publicRoute53HostedZoneId: string;
  publicRoute53HostedZoneName: string;
  domainNames: string[];
  githubRoleArn: string;
  certificateArn: string;
}

const config = loadConfig<MyAxiomConfig>();

// now this should resolve correctly
console.log(config.githubRoleArn);
```
